### PR TITLE
GLM-13645 - Housekeeping > Upgrade to Ruby 4

### DIFF
--- a/data_uri.gemspec
+++ b/data_uri.gemspec
@@ -8,7 +8,6 @@ Gem::Specification.new do |s|
   s.summary     = "A URI class for parsing data URIs as per RFC2397"
 
   s.platform = Gem::Platform::RUBY
-  s.has_rdoc = true
   s.extra_rdoc_files = ["README.rdoc"]
 
   s.require_path = 'lib'


### PR DESCRIPTION
## Change description

This is a necessary step, in order to perform the upgrade of the rails version in the Gleam repo